### PR TITLE
My take

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,23 @@
-FROM almir/webhook
+# Dockerfile for https://github.com/adnanh/webhook
+FROM        golang:alpine3.8 AS build
+MAINTAINER  Almir Dzinovic <almir@dzinovic.net>
+WORKDIR     /go/src/github.com/adnanh/webhook
+ENV         WEBHOOK_VERSION 2.6.9
+RUN         apk add --update -t build-deps curl libc-dev gcc libgcc
+RUN         curl -L --silent -o webhook.tar.gz https://github.com/adnanh/webhook/archive/${WEBHOOK_VERSION}.tar.gz && \
+            tar -xzf webhook.tar.gz --strip 1 &&  \
+            go get -d && \
+            go build -o /usr/local/bin/webhook && \
+            apk del --purge build-deps && \
+            rm -rf /var/cache/apk/* && \
+            rm -rf /go
+
+FROM        alpine:3.8
+RUN         apk update && apk upgrade && apk install java8
+COPY        --from=build /usr/local/bin/webhook /usr/local/bin/webhook
+VOLUME      ["/etc/webhook"]
+EXPOSE      9000
+ENTRYPOINT  ["/usr/local/bin/webhook"]
 
 COPY 		hooks/hooks.json /etc/webhook/hooks.json
 COPY 		hooks/test-docker-iq-hook.json /etc/webhook/test-docker-iq-hook.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN         curl -L --silent -o webhook.tar.gz https://github.com/adnanh/webhook
             rm -rf /go
 
 FROM        alpine:3.8
-RUN         apk update && apk upgrade && apk install java8
+RUN         apk update && apk upgrade && apk add openjdk8-jre
 COPY        --from=build /usr/local/bin/webhook /usr/local/bin/webhook
 VOLUME      ["/etc/webhook"]
 EXPOSE      9000


### PR DESCRIPTION
Went to original dockerfile and brought it in, then added the update, upgrade and install java stuff.

However, if we can accept the almar/webhooks image then perhaps we can trim off the top and just add the apk update, upgrade and install java to your file to keep it shorter and faster

At least we know all of the turtles to the bottom now.